### PR TITLE
Update i18n.ts

### DIFF
--- a/src/lib/helpers/i18n.ts
+++ b/src/lib/helpers/i18n.ts
@@ -50,7 +50,23 @@ export function getI18n() {
         deprecated: 'Descontinuado',
         superseded: 'Cancelado'
       }
-    }
+    },
+    'it-IT: {
+      decision: 'Decisione',
+      Status: 'Stato',
+      statusStr: 'proposta/accettata/implementata/deprecata/sostituita',
+      modifiedDate: 'Ultima Modifica',
+      lastStatus: 'Stato più recente',
+      logSavePath: 'Cartella di salvataggio:',
+      tocHeader: 'Registro Decisioni Architetturali',
+      status: {
+        proposed: 'Proposta',
+        accepted: 'Accettata',
+        done: 'Implementata',
+        deprecated: 'Deprecata',
+        superseded: 'Sostituita'
+      }
+    },
   };
 
   return I18N[language];


### PR DESCRIPTION
add italian locale to i18n

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

* **What is the current behavior?** (You can also link to an open issue here)

It's not possible to generate an italian localized ADR.

* **What is the new behavior (if this is a feature change)?**

`it-IT` language will be available for ADR init command.

* **Other information**:
