### PR TITLE
feat: Adding a newline on toc generation and update

### DIFF
--- a/src/lib/create.ts
+++ b/src/lib/create.ts
@@ -29,5 +29,5 @@ export function create (name: string) {
 
   createDecisions(name, savePath)
   let toc = generate('toc', { output: false })
-  fs.writeFileSync(savePath + 'README.md', toc)
+  fs.writeFileSync(savePath + 'README.md', toc + '\n')
 }

--- a/src/lib/update.ts
+++ b/src/lib/update.ts
@@ -44,7 +44,7 @@ function updateNameByTitle (): void {
 
 function updateToc (): void {
   let toc = generate('toc', { output: false })
-  fs.writeFileSync(savePath + 'README.md', toc)
+  fs.writeFileSync(savePath + 'README.md', toc + '\n')
 }
 
 export function update (): void {


### PR DESCRIPTION
This solves #17. This enables a markdown linter
not to fail because the toc is now commonmark
valid.

Signed-off-by: Johannes Amorosa <johannes.amorosa@endocode.com>