### PR TITLE
fix: avoid 'Expression is always true' error

### DIFF
--- a/src/lib/cache.ts
+++ b/src/lib/cache.ts
@@ -44,7 +44,7 @@ let cache = new Proxy(_cacheInternal, {
       _cacheInternal.init()
     }
 
-    return typeof target[key] === 'function'
+    return target[key] instanceof Function
       ? (target[key] as any).bind(target)
       : target[key]
   }


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

  - Bug fix
      - This PR fixes 'Expression is always true' error when executing `yarn test`

* **What is the current behavior?** (You can also link to an open issue here)

    - ref: #48

* **What is the new behavior (if this is a feature change)?**

    - This change allows the test to pass without 'Expression is always true' error

* **Other information**:

    - The another approach to avoid the error is to suppress 'strict-type-predicates' error:

```
# tslist.json
 {
-  "extends": "tslint-config-standard"
+  "extends": "tslint-config-standard",
+  "rules": {
+    "strict-type-predicates": false
+  }
```

but I rejected the method because it could cause other important errors to be missed
