### PR TITLE
fix: Replace folder separator by - in file name generation

### DIFF
--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -77,7 +77,9 @@ function generateFileName (originFileName) {
   }
 
   return normalizedFileName
-    .replace(/[\s_-]+/g, '-') // swap any length of whitespace, underscore, hyphen characters with a single _
+    .replace(/[\s_-]+/g, '-') // swap any length of whitespace, underscore, hyphen characters with a single -
+    .replace(/\\/g, '-') // swap Windows directory separator by -
+    .replace(/\//g, '-') // swap macOS / Linux directory separator by -
     .replace(/^-+|-+$/g, '') // remove leading, trailing -
     .replace(/，/g, '')
     .replace(/。/g, '')


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Replace folder separator (`/` and `\`) by `-` in file name generation

* **What is the current behavior?** (You can also link to an open issue here)

Those character were kept as-is, which is a problem if those characters are used in the name of the ADR (an example would be an ADR name referencing an HTTP endpoint on a macOS or Linux machine) since it makes the machine search the file at the wrong place:

```sh
$ npx adr new "GET /foobar"
node:fs:2342
    return binding.writeFileUtf8(
                   ^

Error: ENOENT: no such file or directory, open 'doc/adr/00001-get-/foobar.md'
    at Object.writeFileSync (node:fs:2342:20)
    at createDecisions (/home/drakasan/path/to/adr/build/main/lib/create.js:29:8)
    at create (/home/drakasan/path/to/adr/build/main/lib/create.js:37:22)
    at /home/drakasan/path/to/adr/build/main/cli.js:23:29
    at Array.forEach (<anonymous>)
    at Command.<anonymous> (/home/drakasan/path/to/adr/build/main/cli.js:23:12)
    at Command.listener [as _actionHandler] (/home/drakasan/path/to/adr/node_modules/commander/index.js:413:31)
    at Command._parseCommand (/home/drakasan/path/to/adr/node_modules/commander/index.js:914:14)
    at Command._dispatchSubcommand (/home/drakasan/path/to/adr/node_modules/commander/index.js:865:18)
    at Command._parseCommand (/home/drakasan/path/to/adr/node_modules/commander/index.js:882:12) {
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: 'doc/adr/00001-get-/foobar.md'
}

Node.js v20.12.2
```

* **What is the new behavior (if this is a feature change)?**

Those character are replaced by `-`, so the filename generation stay consistent, and generate the file correctly. An example with the same name as above would result in `docs/adr/00001-get--foobar.md`

* **Other information**:

Tested on linux, don't have any windows machine on hand to try it out on.

Since name generation doesn't looks like it is used beyond generation of new file, this shouldn't be a breaking change.

Also fixed the comment to reference the correct character (`_` vs `-`)
