### PR TITLE
fix: Correctly extract decision when used with prefix

### DIFF
--- a/src/lib/base/GenerateBuilder.ts
+++ b/src/lib/base/GenerateBuilder.ts
@@ -1,9 +1,13 @@
 ///<reference path="AbstractBuilder.ts"/>
+let fs = require('fs')
 import { AbstractBuilder } from './AbstractBuilder'
 
+import Config from '../Config'
 import Utils from '../utils'
 import getAdrFiles from '../helpers/getAdrFiles'
 import * as walkSync from 'walk-sync'
+
+let savePath = Config.getSavePath()
 
 export class GenerateBuilder implements AbstractBuilder {
   path: string
@@ -23,12 +27,11 @@ export class GenerateBuilder implements AbstractBuilder {
     let bodyString = this.bodyString
     this.files.forEach(function (file) {
       let fileName = file.relativePath
-      let fileNameLength = fileName.length
-      let numberLength = Utils.getNumberLength(fileName) + '-'.length
-      let markdownWithPrefixLength = '.md'.length
       let index = Utils.getIndexByString(fileName)
+      let fileData = fs.readFileSync(savePath + fileName, 'utf8')
+      let firstLine = fileData.split('\n')[0]
       if (index) {
-        let decision = fileName.substring(numberLength, fileNameLength - markdownWithPrefixLength)
+        let decision = firstLine.replace(/#\s\d+\.\s/g, '')
         handleBody(index, decision, file, bodyString, files.length)
       }
     })

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -91,8 +91,10 @@ function generateFileName (originFileName) {
 }
 
 function getNumberLength (fileName: string): number {
-  let numberLength = fileName.split('-')[0]
-  return numberLength.length
+  let numberLength = fileName
+    .substring(Config.getPrefix().length)
+    .split('-')[0]
+  return Config.getPrefix().length + numberLength.length
 }
 
 function getIndexByString (fileName: string): number {


### PR DESCRIPTION
* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

When using a prefix, the TOC generation was failing since the number detection was failing. Update the number detection to account for the prefix.
The TOC generation was using the filename to create the title, instead, do the same thing as the status listing and open the file to extract the title from inside the ADR.

* **What is the current behavior?** (You can also link to an open issue here)

TOC generator is using `getNumberLength` to find where the number is. This function is taking the first part of the name without taking a potential prefix into account, which may mean the function returns part of the prefix instead of the number.

TOC generator is using the filename to generate the title of the ADR.

* **What is the new behavior (if this is a feature change)?**

Extract the first part of the filename after removing the prefix to extract the number.

Copy `ListGenerateBuilder` and extract the ADR title.

* **Other information**:

Functionally tested successfully on a small test project, but lacking examples to ensure it didn't break anything else.
Unit test are currently failing and needs to be updated before merging